### PR TITLE
Reduce search icon size

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4096M
 android.useAndroidX=true
 android.enableJetifier=true

--- a/assets/html/css/stylesTorah.css
+++ b/assets/html/css/stylesTorah.css
@@ -499,9 +499,9 @@ a {
     color: white;
     border: none;
     border-radius: 50%;
-    width: 80px;
-    height: 80px;
-    font-size: 36px;
+    width: 60px;
+    height: 60px;
+    font-size: 28px;
     cursor: pointer;
     display: flex;
     align-items: center;


### PR DESCRIPTION
Reduce search icon (loupe) size from 80×80px to 60×60px and font-size from 36px to 28px.